### PR TITLE
Remove repeated option use from specification

### DIFF
--- a/draft-amsuess-core-shopinc.md
+++ b/draft-amsuess-core-shopinc.md
@@ -81,9 +81,8 @@ MUST also support the equivalent request composed of Uri-Path components.
 
 | No.    | C | U | N | R | Name           | Format        | Len. | Default |
 |--------+---+---+---+---+----------------+---------------+------+---------|
-| CPA13¹ | x |   |   |   | Uri-Path-Abbr | uint           | 0-4  | (none)  |
-| CPA13² | x |   |   | x | Uri-Path-Abbr | uint / opaque  | any  | (none)  |
-{:#option-table title="Uri-Path-Abbr Option Summary (C = Critical, U = Unsafe, N = NoCacheKey, R = Repeatable). In basic (¹) and extended (²) use"}
+| CPA13  | x |   |   |   | Uri-Path-Abbr | uint           | 0-4  | (none)  |
+{:#option-table title="Uri-Path-Abbr Option Summary (C = Critical, U = Unsafe, N = NoCacheKey, R = Repeatable)"}
 
 [^cpa]
 
@@ -100,16 +99,10 @@ and used in CoAP requests.
 {{option-table}} summarizes these, extending Table 4 of {{RFC7252}}).
 Its OSCORE treatment is as Class E ({{?RFC8613}}).
 
-The (first occurrence of the) option has an integer value
+The option has an integer value
 from the registry established in {{iana-reg}}.
-Unless that entry specifies "extended use",
-the option is used in the simpler "basic use" mode.
 
-Only applications that support entries with extended use need to implement the extensions of {{repeated}}.
-All others can regard the option as non-repeatable and uint valued,
-as long as they treat any additional Uri-Path-Abbr options as the unexpected critical option it is.
-
-Apart from the format,
+Apart from the format and repeatability,
 the option's properties only deviate from the Uri-Path (for which it stands in)
 in that this option is safe to forward.
 This has unfortunate consequences for the interactions with the Proxy-URI option,
@@ -144,54 +137,17 @@ Servers that support both Uri-Path-Abbr and Proxy-URI/-CRI SHOULD process reques
 (This is not a strict requirement, as there are no known implementations of proxies that actually compose a Proxy-URI/-CRI from individual options,
 nor is there a reason known why they should).
 
-## Extended use {#repeated}
+## Future development
 
-[^maybedrop]
+Future updates to this document
+might extend the capabilities of the option to be repeated;
+that document will need to specify how later occurrences of the option
+extend the series of equivalent Uri-Path options from the first value.
 
-[^maybedrop]: This document should also work if we dropped this and references to it completely;
-  it'd then be up to updating documents to "create" extended rules.
-  All that would need to remain is a small note that implementations must properly respond with Bad Option on unexpected occurrences..
-
-If a registered abbreviation describes an entry to apply "extended use",
-the option can be repeated, and have non-uint values ({{option-table}}).
-
-Their value of later options is not expanded through the Uri-Path-Abbr IANA registry,
-but according to rules set up in that particular registration.
-
-To be implementable on a wide variety of platforms,
-those rules should allow expansion into Uri-Path options in an iterative way
-(i.e., any added Uri-Path-Abbr option corresponds only to appended Uri-Path options,
-or cause a 4.02 Bad Option error,
-except if there are no resources at all with that prefix,
-in which case 4.04 Not Found may be used instead).
-
-### Examples of rules
-
-Some rules anticipated to be used are:
-
-* Options after the first are treated exactly like Uri-Path options.
-
-* There can be only one added Uri-Path-Abbr option,
-  and its opaque value is looked up in a table shaped like the Uri-Path-Abbr IANA registry.
-
-## Considerations for choosing rules and prefixes {#rulecons}
-
-As demonstrated with the initial options for {{?RFC9175}} in {{initial}},
-several abbreviations can be registered for a single document;
-those will often use numbers above 256 to be frugal with the namespace.
-Even using two bytes for the number,
-the path is encoded more efficiently than if extended use was specified:
-The total option is 4 byte long, whereas a small number would produce a 3 byte long option followed by a 2 byte repeated option with value.
-
-It is recommended <!-- not normative: doesn't affect interop, just applicant's later options -->
-that the expansion of the first Uri-Path-Abbr option does not end with a trailing slash,
-even when the entry is specified for basic use.
-
-This enables updates to the entry that enable extended use,
-as there is no empty path component that stands in the way of iterative expansion into Uri-Path options.
-Such a change is compatible because clients that use the new behavior
-will receive 4.02 errors from older servers,
-and fall back to sending the path in Uri-Path.
+Server implementations that treat repeated Uri-Path-Abbr options
+like any other critical unprocessable option (i.e., by responding with 4.02 Bad Option)
+support the transition to such an extension.
+<!-- It'd be great to state "this is already required in 7252", but it only implies that and doesn't make it explicit. -->
 
 ## Choice of the option number
 
@@ -285,12 +241,6 @@ Entry fields are:
 
   This field may be empty if the document describes that the option needs to be repeated when using this first value.
 
-* Extended use.
-
-  Brief description of the mode of extended use, or empty (`-`).
-
-  Examples: "Uri-Path string", "table lookup", "custom".
-
 * Reference.
 
   A document that requested the allocation,
@@ -302,29 +252,22 @@ Reviewer instructions:
 The reviewer is instructed to be frugal with the 128 values that correspond to a single-vbyte value,
 focusing on applications that are expected to be useful in different constrained ecosystems.
 
-If the considerations of {{rulecons}} are not followed,
-the reviewer is asked to verify with the applicant that they are deliberately deciding otherwise.
-
-The expanded path (or paths) are expected to be well-known paths at the time of writing,
+The expanded path is expected to be well-known paths at the time of writing,
 but it is up to the reviewers to exceptionally also admit paths that are not well-known.
 
-If the registration foresees updates,
-those should always just allow previously unacceptable values into new path segments,
-and not alter the semantics of previously valid expansions.
-
-| First option value | Simple expanded path | Ext |Reference |
-|--------------------+----------------------+----------------|
-| 0                  | /.well-known/core    | - | {{initial}} of this document                         |
-| 1                  | /.well-known/rd      | - | {{initial}} of this document, and {{?RFC9176}}       |
-| 301                | /.well-known/est/crts  | - | {{initial}} of this document, and {{?RFC9148}}    |
-| 302                | /.well-known/est/sen   | - | {{initial}} of this document, and {{?RFC9148}}    |
-| 303                | /.well-known/est/sren  | - | {{initial}} of this document, and {{?RFC9148}}    |
-| 304                | /.well-known/est/skg   | - | {{initial}} of this document, and {{?RFC9148}}    |
-| 305                | /.well-known/est/skc   | - | {{initial}} of this document, and {{?RFC9148}}    |
-| 306                | /.well-known/est/att   | - | {{initial}} of this document, and {{?RFC9148}}    |
-| 401                | /.well-known/brski/es  | - | {{initial}} of this document, and {{?I-D.ietf-anima-constrained-voucher}}       |
-| 402                | /.well-known/brski/rv  | - | {{initial}} of this document, and {{?I-D.ietf-anima-constrained-voucher}}       |
-| 403                | /.well-known/brski/vs  | - | {{initial}} of this document, and {{?I-D.ietf-anima-constrained-voucher}}       |
+| First option value | Simple expanded path | Reference |
+|--------------------+----------------------+-----------|
+| 0                  | /.well-known/core    | {{initial}} of this document                         |
+| 1                  | /.well-known/rd      | {{initial}} of this document, and {{?RFC9176}}       |
+| 301                | /.well-known/est/crts  | {{initial}} of this document, and {{?RFC9148}}    |
+| 302                | /.well-known/est/sen   | {{initial}} of this document, and {{?RFC9148}}    |
+| 303                | /.well-known/est/sren  | {{initial}} of this document, and {{?RFC9148}}    |
+| 304                | /.well-known/est/skg   | {{initial}} of this document, and {{?RFC9148}}    |
+| 305                | /.well-known/est/skc   | {{initial}} of this document, and {{?RFC9148}}    |
+| 306                | /.well-known/est/att   | {{initial}} of this document, and {{?RFC9148}}    |
+| 401                | /.well-known/brski/es  | {{initial}} of this document, and {{?I-D.ietf-anima-constrained-voucher}}       |
+| 402                | /.well-known/brski/rv  | {{initial}} of this document, and {{?I-D.ietf-anima-constrained-voucher}}       |
+| 403                | /.well-known/brski/vs  | {{initial}} of this document, and {{?I-D.ietf-anima-constrained-voucher}}       |
 {:#initial-table title="Initial values for the Uri-Path-Abbr registry"}
 
 <!-- We could also say in prose to take them from there and list the numbers there, but it is useful for later registrant to have a ready-made template in the document that sets things up. -->


### PR DESCRIPTION
If #13 is the way to go, making "append text string" a default is kind'a unjustified because we don't use it.

Might even go further and leave the whole "extended" thing for later docs – why spend time on something we have no idea if there's ever a good use case.