### PR TITLE
Expanding Proxy-* is really expanding Proxy-Uri/-Cri because the wildcard would also cover Proxy-Scheme

### DIFF
--- a/draft-ietf-core-uri-path-abbrev.md
+++ b/draft-ietf-core-uri-path-abbrev.md
@@ -246,8 +246,8 @@ It is thus generally inconsequential to the client and the server that Proxy-Uri
 
 Endpoints that process both the Proxy-Uri/-Cri and the Uri-Path-Abbrev option
 (that is, servers that are not forwarding like proxies, but are regarded as proxies by other proxies),
-MUST logically decompose the Proxy-\* options into Proxy-Scheme (or Proxy-Scheme-Number) and  Uri-* options before processing the Uri-Path-Abbrev option,
-which entails an error response if both a path segment in the Proxy-\* option and Uri-Path-Abbrev option are present.
+MUST logically decompose the Proxy-Uri/-Cri options into Proxy-Scheme (or Proxy-Scheme-Number) and  Uri-* options before processing the Uri-Path-Abbrev option,
+which entails an error response if both a path segment in a Proxy-Uri/-Cri option and Uri-Path-Abbrev option are present.
 
 ## Choice of the option number
 


### PR DESCRIPTION
Follow-up of https://github.com/core-wg/uri-path-abbrev/pull/42#pullrequestreview-4634272521 because I merged there before discussion concluded.